### PR TITLE
removing obs blocks

### DIFF
--- a/src/_artifacts.tf
+++ b/src/_artifacts.tf
@@ -40,9 +40,6 @@ resource "massdriver_artifact" "vpc" {
           public_subnets   = local.public_subnets
           internal_subnets = local.internal_subnets
         }
-        observability = {
-          alarm_sns_topic_arn = aws_sns_topic.cloudwatch_alarms.arn
-        }
       }
       specs = {
         aws = {

--- a/src/vpc.tf
+++ b/src/vpc.tf
@@ -6,29 +6,3 @@ resource "aws_vpc" "main" {
     Name = var.md_metadata.name_prefix
   }
 }
-
-resource "aws_sns_topic" "cloudwatch_alarms" {
-  name = "${var.md_metadata.name_prefix}-alarms"
-  # https://docs.aws.amazon.com/sns/latest/dg/sns-message-delivery-retries.html
-  delivery_policy = <<EOF
-  {
-    "http": {
-      "defaultHealthyRetryPolicy": {
-        "numNoDelayRetries": 5,
-        "minDelayTarget": 1,
-        "numMinDelayRetries": 5,
-        "maxDelayTarget": 3,
-        "numMaxDelayRetries": 5,
-        "numRetries": 30
-      },
-      "disableSubscriptionOverrides": false
-    }
-  }
-  EOF
-}
-
-resource "aws_sns_topic_subscription" "massdriver_cloudwatch_alarm_subscription" {
-  endpoint  = var.md_metadata.observability.alarm_webhook_url
-  protocol  = "https"
-  topic_arn = aws_sns_topic.cloudwatch_alarms.arn
-}


### PR DESCRIPTION
This is a breaking change to downstream bundles. It will need to be applied after we have migrated to `var.md_metadata`