### PR TITLE
Update the cidr regex to be accurate and have a useful error message

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -26,7 +26,12 @@ params:
     aws_region:
       $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/aws-region.json
     cidr:
-      $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/cidr.json
+      title: VPC CIDR
+      type: string
+      description: Enter a CIDR range to use for the size of your VPC
+      pattern: ^(?:10\.(?:[0-9]|[0-9]{2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])|172\.(?:1[6-9]|2[0-9]|3[0-1])|192\.168)(?:\.(?:[0-9]|[0-9]{2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){2}(?:/(?:1[6-9]|20))$
+      message:
+        pattern: Range must be from private networking space (10.X.X.X, 172.16-31.X.X, 192.168.X.X). Mask must be between 16 and 20
     high_availability:
       type: boolean
       title: NAT Gateway High Availability


### PR DESCRIPTION
Moving the change here since mask has to be pretty specific to AWS. Tested this on https://regex101.com/ and https://rjsf-team.github.io/react-jsonschema-form/ and looks good